### PR TITLE
Switch auditlog-forwarder image repository to the virtual repository 'public'

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -6,7 +6,6 @@
 images:
 - name: auditlog-forwarder
   sourceRepository: github.com/gardener/auditlog-forwarder
-  # repository: europe-docker.pkg.dev/gardener-project/releases/gardener/auditlog-forwarder
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/auditlog-forwarder
   # tag: v0.1.0
-  repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/auditlog-forwarder
   tag: v0.1.0-0cd5e94b6915cbc0f8a54cbc0382c3d47ac1f537


### PR DESCRIPTION
**How to categorize this PR?**
/area audit-logging
/kind enhancement

**What this PR does / why we need it**:
Switch auditlog-forwarder image repository to the virtual repository 'public'

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```