### PR TITLE
Clean the validating webhook configuration for admission in dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ extension-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 
 extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) delete
+	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-auditing-admission --ignore-not-found
 
 extension-operator-up extension-operator-down: export SKAFFOLD_FILENAME = skaffold-operator.yaml
 extension-operator-up: $(SKAFFOLD) $(KIND) $(HELM) $(KUBECTL)

--- a/docs/development/getting-started-locally.md
+++ b/docs/development/getting-started-locally.md
@@ -123,3 +123,9 @@ make extension-operator-down
 ```
 
 The corresponding make target will delete the `Extension.operator.gardener.cloud` resource. Consequently, the gardener-operator will delete the auditing admission component and auditing ControllerDeployment and ControllerRegistration resources.
+
+Finally delete the `ValidatingWebhookConfiguration` from the Virtual Garden cluster.
+
+```bash
+kubectl --kubeconfig $(pwd)/../gardener/dev-setup/kubeconfigs/virtual-garden/kubeconfig delete validatingwebhookconfiguration gardener-extension-auditing-admission --ignore-not-found
+```


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
The admission validating webhook configuration remains after the extension is deleted. As there is no automatic handling we have to delete this explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```