### PR TITLE
Retitle configuration and event format pages

### DIFF
--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring the Auditing Extension (Garden)
+title: Configuration for Garden Clusters
 description: Learn how to enable audit log forwarding for Garden clusters
 ---
 

--- a/docs/operations/event-format.md
+++ b/docs/operations/event-format.md
@@ -1,5 +1,5 @@
 ---
-title: Audit Event Format (Garden)
+title: Event Format for Garden Clusters
 description: Learn about the format of audit events sent from Garden clusters
 ---
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring the Auditing Extension
+title: Configuration for Shoot Clusters
 description: Learn how to enable audit log forwarding for Shoot clusters
 ---
 

--- a/docs/usage/event-format.md
+++ b/docs/usage/event-format.md
@@ -1,9 +1,9 @@
 ---
-title: Audit Event Format
+title: Event Format for Shoot Clusters
 description: Learn about the format of audit events sent to backends and the custom annotations injected by Gardener
 ---
 
-# Audit Event Format
+# Audit Event Format for Shoot Clusters
 
 The auditing extension forwards Kubernetes audit events to the configured backends using the standard Kubernetes Audit API format. The kube-apiserver sends audit events as [EventList](https://kubernetes.io/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-EventList) objects (following the `audit.k8s.io/v1` API schema), where each EventList contains one or more [Event](https://kubernetes.io/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event) objects.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

Retitles the pages `configuration.md` and `event-format.md` in the folders `operations` and `usage`.
The idea is to use similar titles, but explicitly differentiating between usage for `Garden` or `Shoot` clusters.
See also the referenced PR below for background motivation for this change.

**Which issue(s) this PR fixes**:

Follow-up to:
* https://github.com/gardener/documentation/pull/826

**Special notes for your reviewer**:

/cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```