### PR TITLE
Inject garden name and clusterIdentity as audit event annotations

### DIFF
--- a/docs/operations/event-format.md
+++ b/docs/operations/event-format.md
@@ -11,9 +11,11 @@ For a complete overview of the audit event format, see the [Audit Event Format d
 
 When the auditing extension is configured for a Garden cluster (via `operator.gardener.cloud/v1alpha1` Garden resource), the following annotation is added to each audit event:
 
-| Annotation Key                      | Description                                                         | Example                                  |
-|-------------------------------------|---------------------------------------------------------------------|------------------------------------------|
-| `garden.gardener.cloud/id`          | Unique identifier (UID) of the Garden cluster (garden.metadata.uid) | `a1b2c3d4-e5f6-7890-abcd-ef1234567890`   |
+| Annotation Key                          | Description                                                                                  | Example                                  |
+|-----------------------------------------|----------------------------------------------------------------------------------------------|------------------------------------------|
+| `garden.gardener.cloud/id`              | Unique identifier (UID) of the Garden cluster (garden.metadata.uid)                          | `a1b2c3d4-e5f6-7890-abcd-ef1234567890`   |
+| `garden.gardener.cloud/name`            | Name of the Garden resource (garden.metadata.name)                                           | `dev`                                    |
+| `garden.gardener.cloud/clusterIdentity` | Cluster identity of the Garden cluster (garden.spec.virtualCluster.gardener.clusterIdentity) | `garden-dev`                             |
 
 This enables operators to:
 - Correlate audit events with specific Garden clusters
@@ -42,6 +44,8 @@ Below is an example showing the Garden-specific annotations in an audit event:
       // Other fields
       "annotations": {
         "garden.gardener.cloud/id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "garden.gardener.cloud/name": "dev",
+        "garden.gardener.cloud/clusterIdentity": "garden-dev",
         // Other non-Gardener annotations
       }
     }

--- a/pkg/controller/audit/actuator.go
+++ b/pkg/controller/audit/actuator.go
@@ -140,7 +140,9 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 		}
 		referencedResources = garden.Spec.Resources
 		gardenerMetadata = map[string]string{
-			"garden.gardener.cloud/id": string(garden.UID),
+			"garden.gardener.cloud/id":              string(garden.UID),
+			"garden.gardener.cloud/name":            garden.Name,
+			"garden.gardener.cloud/clusterIdentity": garden.Spec.VirtualCluster.Gardener.ClusterIdentity,
 		}
 		caRotationPhase = operatorv1alpha1helper.GetCARotationPhase(garden.Status.Credentials)
 	default:


### PR DESCRIPTION
**How to categorize this PR?**
/area audit-logging
/kind enhancement

**What this PR does / why we need it**:
Inject garden name and clusterIdentity as audit event annotations

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The audit events of the Garden cluster now contain additional annotations `garden.gardener.cloud/name` and `garden.gardener.cloud/clusterIdentity` whose value is `garden.metadata.name` and `garden.spec.virtualCluster.gardener.clusterIdentity` respectively. 
```