### PR TITLE
Switch `.spec.trafficDistribution` field to `PreferSameZone` for Kubernetes 1.34+

### DIFF
--- a/charts/gardener-extension-auditing-admission/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-auditing-admission/charts/runtime/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
-  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
+  {{- end }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}
+  trafficDistribution: PreferSameZone
   {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the topology-aware `Service's` `.spec.trafficDistribution` field from `PreferClose` to `PreferSameZone` for Kubernetes 1.34+.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13942

**Special notes for your reviewer**:
Tested like this:
```
❯ helm template foo ./charts/gardener-extension-auditing-admission/charts/runtime -s templates/service.yaml --set service.topologyAwareRouting.enabled=true --kube-version 1.33.0 | grep trafficDistribution
  trafficDistribution: PreferClose

❯ helm template foo ./charts/gardener-extension-auditing-admission/charts/runtime -s templates/service.yaml --set service.topologyAwareRouting.enabled=true --kube-version 1.34.0 | grep trafficDistribution
  trafficDistribution: PreferSameZone
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `.spec.trafficDistribution` field of the topology-aware Services will be automatically switched from the deprecated `PreferClose` to the new `PreferSameZone` option for Kubernetes 1.34+.
```
