### PR TITLE
Scale down auditlog-forwarder during shoot hibernation

### DIFF
--- a/pkg/component/auditlog-forwarder/deploy.go
+++ b/pkg/component/auditlog-forwarder/deploy.go
@@ -63,6 +63,9 @@ type Values struct {
 
 	// ExtensionClass is the class of the extension (e.g., "shoot" or "garden").
 	ExtensionClass extensionsv1alpha1.ExtensionClass
+
+	// Replicas is the number of replicas for the auditlog-forwarder deployment.
+	Replicas int32
 }
 
 // Output defines a destination where audit events will be forwarded.
@@ -263,7 +266,7 @@ func (r *AuditlogForwarder) computeResourcesData(generatedSecrets map[string]*co
 			Labels:    utils.MergeStringMaps(getLabels(), getHALabels()),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:             ptr.To[int32](1),
+			Replicas:             ptr.To(r.values.Replicas),
 			RevisionHistoryLimit: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: getLabels(),

--- a/pkg/component/auditlog-forwarder/deploy_test.go
+++ b/pkg/component/auditlog-forwarder/deploy_test.go
@@ -453,6 +453,7 @@ var _ = Describe("AuditlogForwarder", func() {
 					},
 				},
 			},
+			Replicas: 1,
 		}
 		deployer = auditlogforwarder.New(fakeClient, fakeClient, namespace, fakeSecretManager, values)
 

--- a/pkg/controller/audit/actuator.go
+++ b/pkg/controller/audit/actuator.go
@@ -77,7 +77,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 	}
 
 	var (
-		// hibernated                  bool // TODO replicas
+		replicas       int32 = 1
 		secretsManager secretsmanager.Interface
 
 		referencedResources []gardencorev1beta1.NamedResourceReference
@@ -97,7 +97,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 		}
 
 		if v1beta1helper.HibernationIsEnabled(cluster.Shoot) {
-			return nil
+			replicas = 0
 		}
 		secretsManager, err = extensionssecretsmanager.SecretsManagerForCluster(
 			ctx,
@@ -189,6 +189,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 		MetadataAnnotations: gardenerMetadata,
 		AuditOutputs:        outputs,
 		ExtensionClass:      extensionClass,
+		Replicas:            replicas,
 	})
 
 	if err = forwarder.Deploy(ctx); err != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality cost
/kind bug

**What this PR does / why we need it**:
Scale down the `auditlog-forwarder` deployment when shoot is hibernated.

**Which issue(s) this PR fixes**:
Fixes #48

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `auditlog-forwarder` deployment is now scaled to 0 during shoot hibernation.
```