### PR TITLE
admission: Prevent leaking the validatingwebhookconfiguration 

### DIFF
--- a/charts/gardener-extension-auditing-admission/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-auditing-admission/charts/runtime/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         - --webhook-config-mode=service
         {{- end}}
         - --webhook-config-namespace={{ .Release.Namespace }}
+        {{- if .Values.gardener.virtualCluster.namespace }}
+        - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}
+        {{- end }}
         {{- if .Values.kubeconfig }}
         - --kubeconfig=/kubeconfig/kubeconfig
         {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This is required in order to prevent leaking of validatingwebhookconfigurations in virtual cluster.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14334 

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-registry-cache/pull/550
and https://github.com/gardener/gardener-extension-otelcol/commit/65f861bbe751b62cf5e69168b0a1d3507f3ac2bd

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The extension-auditing's validatingwebhookconfiguration is no longer leaking in the virtual cluster when the extension-auditing operator.gardener.cloud/v1alpha1.Extension resource is deleted.
```